### PR TITLE
Fix test: test_converter.TestConverter.test_volume_is_indexed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.solr changes
 2.12.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- FIX: Tests by no longer changing global state in `VolumeIndex`.
 
 
 2.12.1 (2017-02-16)

--- a/src/zeit/solr/converter.py
+++ b/src/zeit/solr/converter.py
@@ -289,20 +289,16 @@ class ImageExpireDate(Date):
 
 
 class VolumeIndex(Index):
-    # XXX kludgy special case to only apply to IVolume objects and not to other
+    # Special case: only apply to IVolume objects and not to other
     # ICMSContent that has been adapted to find their IVolume.
 
     def process(self, value, doc_node):
         if not zeit.content.volume.interfaces.IVolume.providedBy(value):
             return
 
-        self.solr = 'product_id'
-        self.append_to_node(value.product.id, doc_node)
-
         if value.date_digital_published:
             solr_date = str(value.date_digital_published).replace(' ', 'T', 1)
             solr_date = solr_date.replace('+00:00', 'Z')
-            self.solr = 'date_digital_published'
             self.append_to_node(unicode(solr_date), doc_node)
 
 
@@ -487,7 +483,8 @@ class SolrConverter(object):
     Date(
         zeit.cms.content.interfaces.ICommonMetadata,
         'tldr_date')
-    VolumeIndex(zeit.cms.interfaces.ICMSContent, None)
+    VolumeIndex(zeit.cms.interfaces.ICMSContent, None,
+                solr='date_digital_published')
     Index(
         zeit.cms.content.interfaces.ICommonMetadata,
         'access')


### PR DESCRIPTION
It could only run alone.

If it ran after `test_does_not_index_volume_properties_for_articles` it broke
because that test changed global data structures in VolumeIndex (aka the `solr` attribute), so the volume index got
omitted in `SolrConverter.convert()` because of the duplicate `product_id` name.

This seems to be broken live, too as indexing a Volume without `date_digital_published` no longer renders this field for all following index calls as the the index has a name which already exists in `SolrConverter.solr_fields_seen`.

This PR supersedes #8.